### PR TITLE
Correct documentation when calling for_controller

### DIFF
--- a/lib/rectify/controller_helpers.rb
+++ b/lib/rectify/controller_helpers.rb
@@ -7,7 +7,7 @@ module Rectify
     def present(presenter, options = {})
       presenter_type = options.fetch(:for) { :template }
 
-      presenter.for_controller(self)
+      presenter.attach_controller(self)
       rectify_presenters[presenter_type] = presenter
     end
 

--- a/lib/rectify/presenter.rb
+++ b/lib/rectify/presenter.rb
@@ -2,8 +2,9 @@ module Rectify
   class Presenter
     include Virtus.model
 
-    def for_controller(controller)
+    def attach_controller(controller)
       @controller = controller
+      self
     end
 
     def method_missing(method_name, *args, &block)

--- a/readme.md
+++ b/readme.md
@@ -527,12 +527,12 @@ class UsersController < ApplicationController
   def show
     user = User.find(params[:id])
 
-    @presenter = UserDetailsPresenter.new(:user => user).for_controller(self)
+    @presenter = UserDetailsPresenter.new(:user => user).attach_controller(self)
   end
 end
 ```
 
-You need to call `#for_controller` and pass it a controller instance which will
+You need to call `#attach_controller` and pass it a controller instance which will
 allow it access to the view helpers. You can then use the Presenter in your
 views as you would expect:
 
@@ -603,7 +603,7 @@ class UsersController < ApplicationController
   def other_action
     user = User.find(params[:id])
 
-    @presenter = UserDetailsPresenter.new(:user => user).for_controller(self)
+    @presenter = UserDetailsPresenter.new(:user => user).attach_controller(self)
     @presenter.user = User.first
   end
 end

--- a/spec/lib/rectify/presenter_spec.rb
+++ b/spec/lib/rectify/presenter_spec.rb
@@ -19,15 +19,21 @@ RSpec.describe Rectify::Presenter do
     end
   end
 
-  describe "#for_controller" do
+  describe "#attach_controller" do
     let(:controller) { EmptyController.new }
 
     context "when a controller is supplied" do
       it "delegates view helper calls to `controller#view_context`" do
         presenter = SimplePresenter.new(:first_name => "Andy")
-        presenter.for_controller(controller)
+        presenter.attach_controller(controller)
 
         expect(presenter.edit_link).to eq('<a href="edit.html">Edit Andy</a>')
+      end
+
+      it "returns the presenter object" do
+        presenter = SimplePresenter.new(:first_name => "Andy")
+
+        expect(presenter.attach_controller(controller)).to eq(presenter)
       end
     end
 


### PR DESCRIPTION
Closes #5 . 
```
@presenter = UserDetailsPresenter.new(:user => user).for_controller(self)
```
Will set `@presenter` to be equal to the controller, rather than the presenter. The change suggested is consistent with the [Presenter Specs](https://github.com/andypike/rectify/blob/master/spec/lib/rectify/presenter_spec.rb#L27-L28)