### PR TITLE
Support Rails 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,37 @@
 PATH
   remote: .
   specs:
-    rectify (0.3.0)
-      activemodel (~> 4.2, >= 4.2.0)
-      activerecord (~> 4.2, >= 4.2.0)
-      activesupport (~> 4.2, >= 4.2.0)
-      virtus (~> 1.0, >= 1.0.5)
-      wisper (~> 1.6, >= 1.6.1)
+    rectify (0.4.0)
+      activemodel (>= 4.2.0)
+      activerecord (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      virtus (~> 1.0.5)
+      wisper (~> 1.6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.2.5.1)
-      actionview (= 4.2.5.1)
-      activesupport (= 4.2.5.1)
+    actionpack (4.2.6)
+      actionview (= 4.2.6)
+      activesupport (= 4.2.6)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.5.1)
-      activesupport (= 4.2.5.1)
+    actionview (4.2.6)
+      activesupport (= 4.2.6)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activemodel (4.2.5.1)
-      activesupport (= 4.2.5.1)
+    activemodel (4.2.6)
+      activesupport (= 4.2.6)
       builder (~> 3.1)
-    activerecord (4.2.5.1)
-      activemodel (= 4.2.5.1)
-      activesupport (= 4.2.5.1)
+    activerecord (4.2.6)
+      activemodel (= 4.2.6)
+      activesupport (= 4.2.6)
       arel (~> 6.0)
-    activesupport (4.2.5.1)
+    activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -44,7 +44,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     builder (3.2.2)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     descendants_tracker (0.0.4)
@@ -77,7 +77,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rake (10.4.2)
+    rake (11.1.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -110,13 +110,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (~> 4.2, >= 4.2.0)
+  actionpack (>= 4.2.0)
   awesome_print (~> 1.6)
   pry (~> 0.10.3)
   rake
   rectify!
   rspec (~> 3.4)
-  rspec-collection_matchers (~> 1.1, >= 1.1.2)
+  rspec-collection_matchers (~> 1.1)
   sqlite3
   wisper-rspec (~> 0.0.2)
 

--- a/lib/rectify/form.rb
+++ b/lib/rectify/form.rb
@@ -6,8 +6,7 @@ module Rectify
     attribute :id, Integer
 
     def self.from_params(params, additional_params = {})
-      params     = params.with_indifferent_access
-      attributes = params
+      attributes = hash_from(params)
         .fetch(mimicked_model_name, {})
         .merge(additional_params)
 
@@ -37,6 +36,11 @@ module Rectify
 
     def self.model_name
       ActiveModel::Name.new(self, nil, mimicked_model_name.to_s.camelize)
+    end
+
+    def self.hash_from(params)
+      params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
+      params.with_indifferent_access
     end
 
     def persisted?

--- a/lib/rectify/version.rb
+++ b/lib/rectify/version.rb
@@ -1,3 +1,3 @@
 module Rectify
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/rectify.gemspec
+++ b/rectify.gemspec
@@ -12,18 +12,18 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
   s.require_paths = ["lib"]
 
-  s.add_dependency "virtus",        "~> 1.0", ">= 1.0.5"
-  s.add_dependency "wisper",        "~> 1.6", ">= 1.6.1"
-  s.add_dependency "activesupport", "~> 4.2", ">= 4.2.0"
-  s.add_dependency "activemodel",   "~> 4.2", ">= 4.2.0"
-  s.add_dependency "activerecord",  "~> 4.2", ">= 4.2.0"
+  s.add_dependency "virtus",        "~> 1.0.5"
+  s.add_dependency "wisper",        "~> 1.6.1"
+  s.add_dependency "activesupport", ">= 4.2.0"
+  s.add_dependency "activemodel",   ">= 4.2.0"
+  s.add_dependency "activerecord",  ">= 4.2.0"
 
-  s.add_development_dependency "actionpack",    "~> 4.2", ">= 4.2.0"
+  s.add_development_dependency "actionpack",    ">= 4.2.0"
   s.add_development_dependency "awesome_print", "~> 1.6"
   s.add_development_dependency "pry",           "~> 0.10.3"
   s.add_development_dependency "wisper-rspec",  "~> 0.0.2"
   s.add_development_dependency "rspec",         "~> 3.4"
-  s.add_development_dependency "rspec-collection_matchers", "~> 1.1", ">= 1.1.2"
+  s.add_development_dependency "rspec-collection_matchers", "~> 1.1"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rake"
 end

--- a/spec/lib/rectify/form_spec.rb
+++ b/spec/lib/rectify/form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Rectify::Form do
 
   describe ".from_params" do
     let(:params) do
-      {
+      ActionController::Parameters.new(
         "id" => "1",
         "user" => {
           "first_name" => "Andy",
@@ -39,7 +39,7 @@ RSpec.describe Rectify::Form do
             { "name" => "Charlie", "number" => "789" }
           ]
         }
-      }
+      )
     end
 
     it "populates attributes from a params hash" do


### PR DESCRIPTION
To enable support for Rails 5

- [x] Update gem constraints
- [x] ActionController::Parameters#with_indifferent_access is deprecated 

Covers issue https://github.com/andypike/rectify/issues/9