### PR TITLE
Populate Form Objects with associated models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rectify (0.4.0)
+    rectify (0.4.1)
       activemodel (>= 4.2.0)
       activerecord (>= 4.2.0)
       activesupport (>= 4.2.0)

--- a/lib/rectify.rb
+++ b/lib/rectify.rb
@@ -8,6 +8,8 @@ require "active_record"
 
 require "rectify/version"
 require "rectify/form"
+require "rectify/form_attribute"
+require "rectify/build_form_from_model"
 require "rectify/command"
 require "rectify/presenter"
 require "rectify/query"

--- a/lib/rectify/build_form_from_model.rb
+++ b/lib/rectify/build_form_from_model.rb
@@ -1,0 +1,35 @@
+module Rectify
+  class BuildFormFromModel
+    def initialize(form_class, model)
+      @form_class = form_class
+      @model = model
+    end
+
+    def build
+      form.tap do
+        matching_attributes.each do |a|
+          model_value = model.public_send(a.name)
+          form.public_send("#{a.name}=", a.value_from(model_value))
+        end
+      end
+    end
+
+    private
+
+    attr_reader :form_class, :form, :model
+
+    def form
+      @form ||= form_class.new
+    end
+
+    def attribute_set
+      form_class.attribute_set
+    end
+
+    def matching_attributes
+      attribute_set
+        .select { |a| model.respond_to?(a.name) }
+        .map    { |a| FormAttribute.new(a) }
+    end
+  end
+end

--- a/lib/rectify/form.rb
+++ b/lib/rectify/form.rb
@@ -16,21 +16,7 @@ module Rectify
     end
 
     def self.from_model(model)
-      new.tap do |form|
-        attribute_set.each do |a|
-          if model.respond_to?(a.name)  # the model has a matching method/attribute
-            model_value = model.public_send(a.name) # get the value of the attribute from the model, could be a collection, other model or simple type
-            if a.primitive.respond_to?(:from_model) # if the form attribute type is a nested form object (belongs_to)
-              form.public_send("#{a.name}=", a.primitive.from_model(model_value)) # use the .from_model method of that form object
-            elsif a.type.respond_to?(:member_type) && a.type.member_type.respond_to?(:from_model) # if the form attribute is a collection (Set or Array) and it contains form objects (has_many)
-              child_forms = model_value.map { |child_model| a.type.member_type.from_model(child_model) } # map each of the associated models to the form object of the collection
-              form.public_send("#{a.name}=", child_forms) # set the form object collection attribute to the mapped collection (array of form objects)
-            else
-              form.public_send("#{a.name}=", model_value) # set the form object attribute to the value returned by the model method/attribute
-            end
-          end
-        end
-      end
+      Rectify::BuildFormFromModel.new(self, model).build
     end
 
     def self.mimic(model_name)

--- a/lib/rectify/form.rb
+++ b/lib/rectify/form.rb
@@ -16,7 +16,21 @@ module Rectify
     end
 
     def self.from_model(model)
-      new(model.attributes)
+      new.tap do |form|
+        attribute_set.each do |a|
+          if model.respond_to?(a.name)  # the model has a matching method/attribute
+            model_value = model.public_send(a.name) # get the value of the attribute from the model, could be a collection, other model or simple type
+            if a.primitive.respond_to?(:from_model) # if the form attribute type is a nested form object (belongs_to)
+              form.public_send("#{a.name}=", a.primitive.from_model(model_value)) # use the .from_model method of that form object
+            elsif a.type.respond_to?(:member_type) && a.type.member_type.respond_to?(:from_model) # if the form attribute is a collection (Set or Array) and it contains form objects (has_many)
+              child_forms = model_value.map { |child_model| a.type.member_type.from_model(child_model) } # map each of the associated models to the form object of the collection
+              form.public_send("#{a.name}=", child_forms) # set the form object collection attribute to the mapped collection (array of form objects)
+            else
+              form.public_send("#{a.name}=", model_value) # set the form object attribute to the value returned by the model method/attribute
+            end
+          end
+        end
+      end
     end
 
     def self.mimic(model_name)

--- a/lib/rectify/form_attribute.rb
+++ b/lib/rectify/form_attribute.rb
@@ -1,0 +1,35 @@
+module Rectify
+  class FormAttribute < SimpleDelegator
+    def value_from(model_value)
+      return declared_class.from_model(model_value) if form_object?
+
+      if collection_of_form_objects?
+        return model_value.map { |child| element_class.from_model(child) }
+      end
+
+      model_value
+    end
+
+    private
+
+    def form_object?
+      declared_class.respond_to?(:from_model)
+    end
+
+    def collection_of_form_objects?
+      collection? && element_class.respond_to?(:from_model)
+    end
+
+    def collection?
+      type.respond_to?(:member_type)
+    end
+
+    def element_class
+      type.member_type
+    end
+
+    def declared_class
+      primitive
+    end
+  end
+end

--- a/lib/rectify/version.rb
+++ b/lib/rectify/version.rb
@@ -1,3 +1,3 @@
 module Rectify
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/readme.md
+++ b/readme.md
@@ -1022,3 +1022,13 @@ rake db:migrate   # => Migrates the test database
 rake db:schema    # => Dumps database schema
 rake g:migration  # => Create a new migration file
 ```
+
+### Releasing a new version
+
+Bump the version in `lib/rectify/version.rb` then do the following:
+
+```
+bundle
+gem build rectify.gemspec
+gem push rectify-0.0.0.gem
+```

--- a/spec/db/migrate/20160418221727_create_contacts.rb
+++ b/spec/db/migrate/20160418221727_create_contacts.rb
@@ -1,0 +1,13 @@
+class CreateContacts < ActiveRecord::Migration
+  def change
+    create_table :contacts do |t|
+      t.integer :user_id, :null => false
+      t.string :name, :null => false, :default => ""
+      t.string :number, :null => false, :default => ""
+
+      t.timestamps :null => false
+    end
+
+    add_index :contacts, :user_id
+  end
+end

--- a/spec/db/migrate/20160418230109_create_addresses.rb
+++ b/spec/db/migrate/20160418230109_create_addresses.rb
@@ -1,0 +1,12 @@
+class CreateAddresses < ActiveRecord::Migration
+  def change
+    create_table :addresses do |t|
+      t.string :street,    :null => false, :default => ""
+      t.string :town,      :null => false, :default => ""
+      t.string :city,      :null => false, :default => ""
+      t.string :post_code, :null => false, :default => ""
+
+      t.timestamps :null => false
+    end
+  end
+end

--- a/spec/db/migrate/20160418230251_add_address_to_user.rb
+++ b/spec/db/migrate/20160418230251_add_address_to_user.rb
@@ -1,0 +1,5 @@
+class AddAddressToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :address_id, :integer
+  end
+end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -11,7 +11,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407192025) do
+ActiveRecord::Schema.define(version: 20160418230251) do
+
+  create_table "addresses", force: :cascade do |t|
+    t.string   "street",     default: "", null: false
+    t.string   "town",       default: "", null: false
+    t.string   "city",       default: "", null: false
+    t.string   "post_code",  default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  create_table "contacts", force: :cascade do |t|
+    t.integer  "user_id",                 null: false
+    t.string   "name",       default: "", null: false
+    t.string   "number",     default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+  add_index "contacts", ["user_id"], name: "index_contacts_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "first_name", default: "",   null: false
@@ -19,6 +38,7 @@ ActiveRecord::Schema.define(version: 20160407192025) do
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
     t.boolean  "active",     default: true, null: false
+    t.integer  "address_id"
   end
 
 end

--- a/spec/fixtures/models/address.rb
+++ b/spec/fixtures/models/address.rb
@@ -1,0 +1,2 @@
+class Address < ActiveRecord::Base
+end

--- a/spec/fixtures/models/contact.rb
+++ b/spec/fixtures/models/contact.rb
@@ -1,0 +1,3 @@
+class Contact < ActiveRecord::Base
+  belongs_to :user
+end

--- a/spec/fixtures/models/user.rb
+++ b/spec/fixtures/models/user.rb
@@ -1,2 +1,4 @@
 class User < ActiveRecord::Base
+  belongs_to :address
+  has_many :contacts
 end

--- a/spec/lib/rectify/form_spec.rb
+++ b/spec/lib/rectify/form_spec.rb
@@ -140,7 +140,19 @@ RSpec.describe Rectify::Form do
 
   describe ".from_model" do
     let(:model) do
-      User.new(:first_name => "Andy", :age => 38)
+      User.new(
+        :first_name => "Andy",
+        :age        => 38,
+        :contacts   => [
+          Contact.new(:name => "James", :number => "12345")
+        ],
+        :address => Address.new(
+          :street    => "1 High Street",
+          :town      => "Wimbledon",
+          :city      => "London",
+          :post_code => "SW19 1AB"
+        )
+      )
     end
 
     it "populates attributes from an ActiveModel" do
@@ -149,6 +161,27 @@ RSpec.describe Rectify::Form do
       expect(form).to have_attributes(
         :first_name => "Andy",
         :age => 38
+      )
+    end
+
+    it "populates attributes from a model with a has_many" do
+      form = UserForm.from_model(model)
+
+      expect(form.contacts).to have(1).item
+      expect(form.contacts.first).to have_attributes(
+        :name   => "James",
+        :number => "12345"
+      )
+    end
+
+    it "populates attributes from a model with a belongs_to" do
+      form = UserForm.from_model(model)
+
+      expect(form.address).to have_attributes(
+        :street    => "1 High Street",
+        :town      => "Wimbledon",
+        :city      => "London",
+        :post_code => "SW19 1AB"
       )
     end
   end


### PR DESCRIPTION
Not ready for review yet, needs refactoring.

Add support for populating Form Objects when the model specifies `has_many` and `belongs_to` associated models when using `.from_model`.