### PR TITLE
Relax dependencies: Rails >= 4.1 and Wisper >= 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,11 @@ PATH
   remote: .
   specs:
     rectify (0.6.0)
-      activemodel (>= 4.2.0)
-      activerecord (>= 4.2.0)
-      activesupport (>= 4.2.0)
+      activemodel (>= 4.1.0)
+      activerecord (>= 4.1.0)
+      activesupport (>= 4.1.0)
       virtus (~> 1.0.5)
-      wisper (~> 1.6.1)
+      wisper (>= 1.6.1)
 
 GEM
   remote: https://rubygems.org/
@@ -116,7 +116,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (>= 4.2.0)
+  actionpack (>= 4.1.0)
   awesome_print (~> 1.6)
   pry (~> 0.10.3)
   rake

--- a/rectify.gemspec
+++ b/rectify.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "virtus",        "~> 1.0.5"
-  s.add_dependency "wisper",        "~> 1.6.1"
-  s.add_dependency "activesupport", ">= 4.2.0"
-  s.add_dependency "activemodel",   ">= 4.2.0"
-  s.add_dependency "activerecord",  ">= 4.2.0"
+  s.add_dependency "wisper",        ">= 1.6.1"
+  s.add_dependency "activesupport", ">= 4.1.0"
+  s.add_dependency "activemodel",   ">= 4.1.0"
+  s.add_dependency "activerecord",  ">= 4.1.0"
 
-  s.add_development_dependency "actionpack",    ">= 4.2.0"
+  s.add_development_dependency "actionpack",    ">= 4.1.0"
   s.add_development_dependency "awesome_print", "~> 1.6"
   s.add_development_dependency "pry",           "~> 0.10.3"
   s.add_development_dependency "rspec",         "~> 3.4"


### PR DESCRIPTION
We are using Rails 4.1 and Wisper 2.0.0.rc1 and both seems to be working.

Only thing we did not test at this moment is `Rectify::Query`