### PR TITLE
Implement `to_ary` in Query

### DIFF
--- a/lib/rectify/query.rb
+++ b/lib/rectify/query.rb
@@ -52,6 +52,8 @@ module Rectify
       cached_query.to_a
     end
 
+    alias to_ary to_a
+
     def relation?
       cached_query.is_a?(ActiveRecord::Relation)
     end

--- a/spec/lib/rectify/query_spec.rb
+++ b/spec/lib/rectify/query_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Rectify::Query do
       end
     end
 
+    describe "#to_ary" do
+      it "returns the objects as an array" do
+        a = User.create!(:first_name => "Amber", :age => 10)
+        m = User.create!(:first_name => "Megan", :age => 9)
+
+        expect(AllUsers.new.to_ary).to match_array([a, m])
+      end
+    end
+
     describe "#map" do
       it "returns the mapped collection" do
         User.create!(:first_name => "Amber", :age => 10)
@@ -216,6 +225,15 @@ RSpec.describe Rectify::Query do
       end
     end
 
+    describe "#to_ary" do
+      it "returns the objects as an array" do
+        a = User.create!(:first_name => "Amber", :age => 10)
+        m = User.create!(:first_name => "Megan", :age => 9)
+
+        expect(UsersOverUsingSql.new(0).to_ary).to match_array([a, m])
+      end
+    end
+
     describe "#map" do
       it "returns the mapped collection" do
         User.create!(:first_name => "Amber", :age => 10)
@@ -235,6 +253,7 @@ RSpec.describe Rectify::Query do
         query.exists?
         query.none?
         query.to_a
+        query.to_ary
       end.to make_database_queries_of(1)
     end
 


### PR DESCRIPTION
I'm using `rectify` at https://github.com/codegram/decidim/pull/147 and I'm having problems trying to render the results of a query object in a view using both these methods:

```ruby
render(participatory_processes)
```
```ruby
<%= render partial: "promoted_process", collection: promoted_processes, as: :promoted_process %>
```

I'm getting this error:

```
#<Decidim::PublishedProcesses ...> is not an ActiveModel-compatible object. It must implement :to_partial_path
```

My first try was calling the `query` method on the query object in the view:

```ruby
render(participatory_processes.query)
```

This didn't raise any error, but didn't render anything actually so it's not useful. Also, explicitly calling this method from the view feels weird.

Checking the Rails source code, Rails tries to check if the collection passed to the `render` method responds to `to_ary`. If it does not, it uses an empty array as the collection and thus it does not render anything (which is weird, actually):

https://github.com/rails/rails/blob/28a6571bae1d6bc1c774e8e501720374061a31f1/actionview/lib/action_view/renderer/partial_renderer.rb#L406

So my take is defining the `to_ary` method in the Query class as an alias from `to_a`. Both the unit tests and the tests I took on my app are green with this change.