### PR TITLE
Allow id to be string to support not integer ids (postgresql uuid)

### DIFF
--- a/lib/rectify/form.rb
+++ b/lib/rectify/form.rb
@@ -5,7 +5,7 @@ module Rectify
 
     attr_reader :context
 
-    attribute :id, Integer
+    attribute :id, String
 
     def self.from_params(params, additional_params = {})
       params_hash = hash_from(params)
@@ -55,7 +55,11 @@ module Rectify
     end
 
     def persisted?
-      id.present? && id.to_i > 0
+      id.present?
+    end
+
+    def new_record?
+      id.blank?
     end
 
     def valid?(context = nil)


### PR DESCRIPTION
Record identifier type can be anything else, so it's better to use String type