### PR TITLE
Allow a Form to mimic a model with an attribute with the same name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Layout/IndentationWidth:
   Width: 2  
 
 Metrics/ClassLength:
-  Max: 110
+  Max: 115
   Exclude:
     - 'spec/**/*_spec.rb'
 

--- a/lib/rectify/form.rb
+++ b/lib/rectify/form.rb
@@ -10,9 +10,11 @@ module Rectify
     def self.from_params(params, additional_params = {})
       params_hash = hash_from(params)
 
+      mimicked_params = params_hash[mimicked_model_name]
+      mimicked_params = {} unless mimicked_params.is_a?(Hash)
+
       attributes_hash = params_hash
-        .fetch(mimicked_model_name, {})
-        .merge(params_hash)
+        .merge(mimicked_params)
         .merge(additional_params)
 
       formatted_attributes = FormatAttributesHash

--- a/lib/rectify/form.rb
+++ b/lib/rectify/form.rb
@@ -9,9 +9,7 @@ module Rectify
 
     def self.from_params(params, additional_params = {})
       params_hash = hash_from(params)
-
-      mimicked_params = params_hash[mimicked_model_name]
-      mimicked_params = {} unless mimicked_params.is_a?(Hash)
+      mimicked_params = ensure_hash(params_hash[mimicked_model_name])
 
       attributes_hash = params_hash
         .merge(mimicked_params)
@@ -54,6 +52,14 @@ module Rectify
     def self.hash_from(params)
       params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
       params.with_indifferent_access
+    end
+
+    def self.ensure_hash(object)
+      if object.is_a?(Hash)
+        object
+      else
+        {}
+      end
     end
 
     def persisted?

--- a/spec/db/migrate/20180531090029_add_user_to_user.rb
+++ b/spec/db/migrate/20180531090029_add_user_to_user.rb
@@ -1,0 +1,5 @@
+class AddUserToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :user, :string
+  end
+end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2016_05_25_115421) do
+ActiveRecord::Schema.define(version: 2018_05_31_090029) do
 
   create_table "addresses", force: :cascade do |t|
     t.string "street", default: "", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2016_05_25_115421) do
     t.boolean "active", default: true, null: false
     t.integer "address_id"
     t.datetime "last_logged_in"
+    t.string "user"
   end
 
 end

--- a/spec/fixtures/forms/user_form.rb
+++ b/spec/fixtures/forms/user_form.rb
@@ -4,6 +4,7 @@ require_relative "contact_form"
 class UserForm < Rectify::Form
   mimic :user
 
+  attribute :user,        String
   attribute :first_name,  String
   attribute :age,         Integer
   attribute :colours,     Array

--- a/spec/lib/rectify/form_spec.rb
+++ b/spec/lib/rectify/form_spec.rb
@@ -1,18 +1,24 @@
 RSpec.describe Rectify::Form do
   describe ".new" do
     it "populates attributes from a string key hash" do
-      form = UserForm.new("first_name" => "Andy", "age" => 38)
+      form = UserForm.new(
+        "user" => "andy38",
+        "first_name" => "Andy",
+        "age" => 38
+      )
 
       expect(form).to have_attributes(
+        :user       => "andy38",
         :first_name => "Andy",
         :age => 38
       )
     end
 
     it "populates attributes from a symbol key hash" do
-      form = UserForm.new(:first_name => "Andy", :age => 38)
+      form = UserForm.new(:user => "andy38", :first_name => "Andy", :age => 38)
 
       expect(form).to have_attributes(
+        :user       => "andy38",
         :first_name => "Andy",
         :age => 38
       )
@@ -25,6 +31,7 @@ RSpec.describe Rectify::Form do
         "id"       => "1",
         "other_id" => "2",
         "user" => {
+          "user"       => "andy38",
           "first_name" => "Andy",
           "age"        => "38",
           "colours"    => %w[red blue green],
@@ -48,6 +55,7 @@ RSpec.describe Rectify::Form do
       form = UserForm.from_params(params)
 
       expect(form).to have_attributes(
+        :user       => "andy38",
         :first_name => "Andy",
         :age        => 38,
         :colours    => %w[red blue green]
@@ -131,6 +139,7 @@ RSpec.describe Rectify::Form do
       form = ChildForm.from_params(params)
 
       expect(form).to have_attributes(
+        :user       => "andy38",
         :first_name => "Andy",
         :age        => 38,
         :school     => "Rutlish"
@@ -161,6 +170,7 @@ RSpec.describe Rectify::Form do
   describe ".from_model" do
     let(:model) do
       User.new(
+        :user       => "andy38",
         :first_name => "Andy",
         :age        => 38,
         :contacts   => [
@@ -180,6 +190,7 @@ RSpec.describe Rectify::Form do
       form = UserForm.from_model(model)
 
       expect(form).to have_attributes(
+        :user       => "andy38",
         :first_name => "Andy",
         :age => 38
       )
@@ -217,6 +228,7 @@ RSpec.describe Rectify::Form do
     it "populates attributes from a json string" do
       json = <<-JSON
         {
+          "user": "andy38",
           "first_name": "Andy",
           "age": 38,
           "address": {
@@ -231,6 +243,7 @@ RSpec.describe Rectify::Form do
       form = UserForm.from_json(json)
 
       expect(form).to have_attributes(
+        :user       => "andy38",
         :first_name => "Andy",
         :age => 38
       )


### PR DESCRIPTION
Currently, having a Form with an attribute with the same name of the mimicked model does not work well. In some cases, the value of the attribute is overwritten with the mimicked model data, resulting in invalid data.

With these changes, data from the mimicked model will override the `params_hash` hash values and the behavior will be the right one.

The only unsupported scenario is when the attribute contains a hash value, as it would be very difficult for the code to determine if the hash is the mimicked model information or the value for the attribute.

I modified tests to check this situation.