### PR TITLE
Add nested forms with nested arrays support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ rvm:
  - "2.3.7"
  - "2.4.4"
  - "2.5.1"
+before_install: gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 script: bundle exec rspec

--- a/spec/fixtures/forms/user_form.rb
+++ b/spec/fixtures/forms/user_form.rb
@@ -4,14 +4,15 @@ require_relative "contact_form"
 class UserForm < Rectify::Form
   mimic :user
 
-  attribute :user,        String
-  attribute :first_name,  String
-  attribute :age,         Integer
-  attribute :colours,     Array
-  attribute :address,     AddressForm
-  attribute :contacts,    Array[ContactForm]
-  attribute :order_count, Integer
-  attribute :other_id,    Integer
+  attribute :user,            String
+  attribute :first_name,      String
+  attribute :age,             Integer
+  attribute :colours,         Array
+  attribute :address,         AddressForm
+  attribute :primary_contact, ContactForm
+  attribute :contacts,        Array[ContactForm]
+  attribute :order_count,     Integer
+  attribute :other_id,        Integer
   attribute :last_login_date, String
 
   validates :first_name, :presence => true

--- a/spec/lib/rectify/form_spec.rb
+++ b/spec/lib/rectify/form_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Rectify::Form do
       expect(form.contacts[2].number).to eq("789")
     end
 
-    it "populates nested indexed arrays of attributes" do
+    it "populates nested indexed arrays of array attributes" do
       params = ActionController::Parameters.new(
         "user" => {
           "contacts" => {
@@ -161,6 +161,30 @@ RSpec.describe Rectify::Form do
       expect(form.contacts[0].phones[1].country_code).to eq("+34")
       expect(form.contacts[1].name).to eq("Megan")
       expect(form.contacts[1].number).to eq("456")
+    end
+
+    it "populates nested indexed arrays of nested form attributes" do
+      params = ActionController::Parameters.new(
+        "user" => {
+          "primary_contact" => {
+            "name" => "Amber",
+            "number" => "123",
+            "phones" => {
+              "0" => { "number" => "111111111", "country_code" => "+34" },
+              "1" => { "number" => "222222222", "country_code" => "+34" }
+            }
+          }
+        }
+      )
+
+      form = UserForm.from_params(params)
+
+      expect(form.primary_contact.name).to eq("Amber")
+      expect(form.primary_contact.number).to eq("123")
+      expect(form.primary_contact.phones[0].number).to eq("111111111")
+      expect(form.primary_contact.phones[0].country_code).to eq("+34")
+      expect(form.primary_contact.phones[1].number).to eq("222222222")
+      expect(form.primary_contact.phones[1].country_code).to eq("+34")
     end
 
     it "populates a derived form" do


### PR DESCRIPTION
Hello @andypike!

I have nested form in my app. A model has a `has_one` relationship that has a `has_many` relationship but `Rectify::Form.from_params` method does not support this case out of the box. I added support for this case.

Note: I fixed travis config to avoid this problem with ruby 2.5.1 https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html