### PR TITLE
Allow kwargs

### DIFF
--- a/lib/rectify/command.rb
+++ b/lib/rectify/command.rb
@@ -41,9 +41,9 @@ module Rectify
       ActiveRecord::Base.transaction(&block) if block_given?
     end
 
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
       if @caller.respond_to?(method_name, true)
-        @caller.send(method_name, *args, &block)
+        @caller.send(method_name, *args, **kwargs, &block)
       else
         super
       end


### PR DESCRIPTION
# Use case

Tried this today:
```ruby
class SomeController < ApplicationController
  def some_action
    SomeCommand.call do
      on(:something) do
        some_method_with_kwargs(yeet:)
      end
    end
  end

  private

  def some_method_with_kwargs(yeet:); end
end
```

Which doesn't work. This **uber small** pr solves that. Also doesn't seem to break anything

@andypike let me know if I should add tests for this or smth